### PR TITLE
Use List<Boolean> instead of boolean[] in Set

### DIFF
--- a/src/main/java/ee/ut/cs/aa/grading/lab_2/combinatorics/BitVectorGenerator.java
+++ b/src/main/java/ee/ut/cs/aa/grading/lab_2/combinatorics/BitVectorGenerator.java
@@ -1,5 +1,6 @@
 package ee.ut.cs.aa.grading.lab_2.combinatorics;
 
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -12,5 +13,5 @@ public interface BitVectorGenerator {
      *
      * @param length of generated bit vectors
      */
-    Set<boolean[]> bitVectors(int length);
+    Set<List<Boolean>> bitVectors(int length);
 }


### PR DESCRIPTION
`BitVectorGenerator` interface uses the type `Set<boolean[]>`. The problem with this type is demonstrated by the following example:

``` java
Set<boolean[]> wat = new HashSet<>();
boolean[] arr = {true};
wat.add(arr);
wat.add(arr);
wat.add(new boolean[]{true});
System.out.println(wat.size()); // 2
```

([running example](http://ideone.com/XDwSie))

All arrays (including those of primitives) are objects which **do not** override `equals` method. This means `Object.equals` is used which doesn't compare the content of arrays. This fact makes the use of `boolean[]` in a `Set` essentially useless because it's neither correct nor reliable as all of `Set`'s methods rely on correct implementation of `equals`.

Instead `List<Boolean>` has properly implemented `equals` method, fixing the issue above:

``` java
Set<List<Boolean>> noWat = new HashSet<>();
List<Boolean> list = Arrays.asList(true);
noWat.add(list);
noWat.add(list);
noWat.add(Arrays.asList(true));
System.out.println(noWat.size()); // 1
```

([running example](http://ideone.com/XDwSie))

In addition `List`s are much easier to manipulate than arrays, making the task less about reinventing the wheel which is `List`.
